### PR TITLE
There's a performance gain in using the element property (s.src) over se...

### DIFF
--- a/jquerify.js
+++ b/jquerify.js
@@ -5,7 +5,7 @@
     if ( !window.jQuery ) {
         var jQ = document.createElement('script');
         var prop = typeof jQ.src;
-        if ( prop != undefined && prop.toLowerCase() == 'string' )
+        if ( prop != 'undefined' && prop.toLowerCase() == 'string' )
             jQ.src = '//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js';
         else
             jQ.setAttribute( 'src', '//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js' );


### PR DESCRIPTION
...tAttribute

Check if `src` exists as property of the element type and it's actually a of type string. If so we can directly assign our src string. Otherwise we use `setAttribute`
