### PR TITLE
Remove { url: dataURL } - directly output dataURL

### DIFF
--- a/snippets/dataurl.js
+++ b/snippets/dataurl.js
@@ -14,19 +14,19 @@
 
     try {
       ctx.drawImage(i, 0, 0);
-      console.log(i, { url: c.toDataURL() });
+      console.log(i, c.toDataURL());
     }
     catch(e) {
-      console.log(i, { url: "No Permission"});
+      console.log(i, "No Permission");
     }
   });
 
   [].forEach.call(document.querySelectorAll("canvas"), function(c) {
     try {
-      console.log(c, { url: c.toDataURL() });
+      console.log(c, c.toDataURL());
     }
     catch(e) {
-      console.log(c, { url: "No Permission"});
+      console.log(c, "No Permission");
     }
   });
 


### PR DESCRIPTION
If you log dataURL within object you can't directly open it in new browser tab/window. Also it's easier to copy the dataURL.
What do you think?
