### PR TITLE
Add border-color to property list

### DIFF
--- a/snippets/allcolors.js
+++ b/snippets/allcolors.js
@@ -45,7 +45,7 @@
 
   console.group("All colors used in elements on the page");
   allColorsSorted.forEach(function (c) {
-    console.groupCollapsed("%c____%c " + c.key + " %c(" + c.value.count + " times)",
+    console.groupCollapsed("%c    %c " + c.key + " %c(" + c.value.count + " times)",
       colorStyle(c.key), nameStyle, countStyle);
     c.value.nodes.forEach(function (node) {
       console.log(node);


### PR DESCRIPTION
The result of border-color is a string like "rgb(255, 0, 0) rgb(0, 0, 255) rgb(0, 128, 0) rgb(255, 255, 0)".
I remove the duplicates and only use the unique color values of "border-color" property.

Changed the placeholder for color (%c____%c => %c    %c). Otherwise you see the underscores on rgba colors.

What do you think about that? If you don't want parse the border-color maybe you can change the placeholder.
