### PR TITLE
Printing all forms with their controls (input, textarea and select elements)

### DIFF
--- a/snippets/formcontrols.js
+++ b/snippets/formcontrols.js
@@ -1,0 +1,30 @@
+// formcontrols.js
+// https://github.com/bgrins/devtools-snippets
+// Print out forms and their controls
+
+(function() {
+
+  var forms = document.querySelectorAll("form");
+
+  for (var i = 0, len = forms.length; i < len; i++) {
+    var tab = [ ];
+
+    console.group("HTMLForm \"" + forms[i].name + "\"");
+    console.log("Name:   "+forms[i].name+"\nMethod: "+forms[i].method.toUpperCase()+"\nAction: "+forms[i].action || "null");
+
+    ["input", "textarea", "select"].forEach(function (control) {
+      [].forEach.call(forms[i].querySelectorAll(control), function (node) {
+        tab.push({
+          "NodeName": node.nodeName.toLowerCase(),
+          "Type": node.type,
+          "Name": node.name,
+          "Value": node.value,
+          "Pretty Value": (isNaN(node.value) || node.value === "" ? node.value : parseFloat(node.value))
+        });
+      });
+    });
+
+    console.table(tab);
+    console.groupEnd();
+  }
+})();


### PR DESCRIPTION
Show all html form elements with their controls (input, textarea and select elements). 
Every form element is a separate table.
Maybe you can include this to your snippets.
What do you think about that? 
