### PR TITLE
Squashed commit of the following: Fix issue 42

### DIFF
--- a/snippets/html_i18n_content/html_i18n_content.js
+++ b/snippets/html_i18n_content/html_i18n_content.js
@@ -52,6 +52,7 @@ try {
     var i18nForInnerText = function(select, messages) {
         var nds = document.querySelectorAll(select);
         for (i = 0, len = nds.length; i < len; i++) {
+            // TODO Please note we use .innerText because it preserves newline characters in Chrome, while .textContent loses them.
             var value = nds[i].innerText;
             if (nds[i].childElementCount === 0 && value) {
                 var key = nds[i].className;
@@ -62,6 +63,13 @@ try {
                     // nds[i].innerText = '';
                     messages = addKeyValuePlaceHolders(messages, key, value);
                 }
+            }
+        }
+        var i18nNodes = document.querySelectorAll(select + '[i18n-content]');
+        for (i = 0, len = i18nNodes.length; i < len; i++) {
+            if (i18nNodes[i].hasAttribute('i18n-content') && i18nNodes[i].childElementCount > 0) {
+                console.warn('HTML elements have been added to\n%O\nPlease only use text and named character references (%o)!',
+                i18nNodes[i], 'https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Introduction#Named_character_references');
             }
         }
     };
@@ -101,12 +109,17 @@ try {
                 if (event.target.readyState !== 'complete') {
                     return;
                 }
+                if (!chrome.i18n) {
+                    console.warn('chrome.i18n is undefined.\n%s\nis %cnot%c viewed as part of a chrome extension.', document.URL, 'font-weight: bold', '');
+                    return;
+                }
                 (function() {
                     var nds = document.querySelectorAll('[i18n-content]');
                     for (i = 0, len = nds.length; i < len; i++) {
                         var value = nds[i].getAttribute('value');
                         var key = nds[i].getAttribute('i18n-content');
                         if (value === null) {
+                            // TODO Please note we use .innerText because it preserves newline characters in Chrome, while .textContent loses them.
                             nds[i].innerText = chrome.i18n.getMessage(key);
                         } else {
                             nds[i].setAttribute('value', chrome.i18n.getMessage(key));


### PR DESCRIPTION
Supersedes earlier pull request (which I will close now).

commit 30680aeabad159ab79d1af2e3f29ea67290fdcec
Author: Adrian Aichner adrian.aichner@gmail.com
Date:   Tue Nov 26 13:08:38 2013 +0100

```
Clarify reason for use of innerText.
Improve wording of a warning.

Untangle from issue35 with "git rebase -i 67ecc84"
```

commit 69c19e6b1ec257ee30989b7cfd786b07f5d9bbfe
Author: Adrian Aichner adrian.aichner@gmail.com
Date:   Thu Nov 7 00:51:41 2013 +0100

```
Improve text content restriction warning.
```

commit ade1c6db8316a15736576542e2a6a48d7b03b090
Author: Adrian Aichner adrian.aichner@gmail.com
Date:   Wed Nov 6 19:09:42 2013 +0100

```
Warn about *[i18n-content] elements having child elements (not supported).

Pushing HTML content markup to chrome.i18n message files would be a bad idea.

Add warning to applyChromeI18nMessages.js when chrome.i18n is not available, but tolerate it (using chrome extension pages stand-alone for content  development).
```
