### PR TITLE
Fix for complex applications. Uncaught TypeError: Cannot convert object to primitive value.

### DIFF
--- a/snippets/log-globals/log-globals.js
+++ b/snippets/log-globals/log-globals.js
@@ -1,6 +1,7 @@
 /*
 	log-globals
 	by Sindre Sorhus
+	modified by Andy Hawkins (http://a904guy.com)
 	https://github.com/sindresorhus/log-globals
 	MIT License
 */

--- a/snippets/log-globals/log-globals.js
+++ b/snippets/log-globals/log-globals.js
@@ -30,5 +30,5 @@
 		return ret;
 	}
 
-	console.log(detectGlobals());
+	return detectGlobals();
 })();


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot convert object to primitive value` found when executed on http://www.linkedIn.com/pulse/
Just let chrome handle return, it will result in the same outcome.

Expected Outcome (after fix):
![image](https://cloud.githubusercontent.com/assets/404081/12068042/1967600a-afd3-11e5-8ead-8b9858b77fed.png)

Error encountered:
![image](https://cloud.githubusercontent.com/assets/404081/12068054/48c2f1ca-afd3-11e5-9635-986ca733d115.png)
