### PR TITLE
Cookie string parsing fixes

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -74,7 +74,7 @@
     },
     {
       "name": "viewcookies",
-      "content": "// viewcookies.js\n// https://github.com/bgrins/devtools-snippets\n// Shows all cookies stored in document.cookies in a console.table\n\n(function() {\n  window.viewCookies = function() {\n    var rawCookies = document.cookie.split(';'), cookies = [];\n    rawCookies.forEach(function(cookie) {\n      var parsedCookie = cookie.split('='), cookieData = {};\n      cookies.push({\n        'key': parsedCookie.shift(),\n        'value': decodeURIComponent(parsedCookie.join('='))\n      });\n    });\n    console.table(cookies);\n  };\n})();\n\nwindow.viewCookies();\n"
+      "content": "// viewcookies.js\n// https://github.com/bgrins/devtools-snippets\n// Shows all cookies stored in document.cookies in a console.table\n\n(function() {\n  'use strict';\n\n  window.viewCookies = function() {\n    if (document.cookie) {\n      const cookies = document.cookie\n        .split(/; ?/)\n        .map(s => {\n          const [ , key, value ] = s.match(/^(.*?)=(.*)$/);\n          return {\n            key,\n            value: decodeURIComponent(value)\n          };\n        });\n\n      console.table(cookies);\n    }\n    else {\n      console.warn('document.cookie is empty!');\n    }\n  };\n})();\n\nwindow.viewCookies();\n"
     },
     {
       "name": "wrapelement",

--- a/snippets/viewcookies/viewcookies.js
+++ b/snippets/viewcookies/viewcookies.js
@@ -3,16 +3,25 @@
 // Shows all cookies stored in document.cookies in a console.table
 
 (function() {
+  'use strict';
+
   window.viewCookies = function() {
-    var rawCookies = document.cookie.split(';'), cookies = [];
-    rawCookies.forEach(function(cookie) {
-      var parsedCookie = cookie.split('='), cookieData = {};
-      cookies.push({
-        'key': parsedCookie.shift(),
-        'value': decodeURIComponent(parsedCookie.join('='))
-      });
-    });
-    console.table(cookies);
+    if (document.cookie) {
+      const cookies = document.cookie
+        .split(/; ?/)
+        .map(s => {
+          const [ , key, value ] = s.match(/^(.*?)=(.*)$/);
+          return {
+            key,
+            value: decodeURIComponent(value)
+          };
+        });
+
+      console.table(cookies);
+    }
+    else {
+      console.warn('document.cookie is empty!');
+    }
   };
 })();
 


### PR DESCRIPTION
Fixes a couple of issues with the way items were being parsed:

* `document.cookie` items are separated in both Chrome and Firefox with `;` and a single-space rather than just the semi-colon
* individual `key=value` items can have values containing an `=` character

It also displays a message if `document.cookie` is an empty string.